### PR TITLE
API version v3

### DIFF
--- a/plugins/init.js
+++ b/plugins/init.js
@@ -9,7 +9,10 @@ async function initPlugin (app) {
     // every time, because the token might be expired
     // And we cannot set the global dispatcher because it's shared with the runtime main thread.
     setDefaultHeaders(await app.getAuthorizationHeader())
-    const request = { podId }
+    const request = {
+      podId,
+      apiVersion: 'v3'
+    }
     if (applicationName) {
       request.applicationName = applicationName
     }

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -191,6 +191,7 @@ test('init plugin sends correct request structure when PLT_APP_NAME provided', a
   equal(capturedRequest.params.podId, instanceId)
   equal(capturedRequest.body.applicationName, applicationName)
   equal(capturedRequest.body.podId, instanceId)
+  equal(capturedRequest.body.apiVersion, 'v3')
 })
 
 test('init plugin sends request without applicationName when not provided', async (t) => {
@@ -237,6 +238,7 @@ test('init plugin sends request without applicationName when not provided', asyn
   equal(capturedRequest.params.podId, instanceId)
   equal(capturedRequest.body.podId, instanceId)
   equal(capturedRequest.body.applicationName, undefined)
+  equal(capturedRequest.body.apiVersion, 'v3')
 
   // But app should have the name from ICC response
   equal(app.applicationName, applicationName)


### PR DESCRIPTION
So ICC can use the Apiversion to identify the caller and reture the `v3` config to watt-extra