### PR TITLE
feat: report scheduler jobs to ICC and execute centrally coordinated runs

### DIFF
--- a/clients/control-plane/control-plane-types.d.ts
+++ b/clients/control-plane/control-plane-types.d.ts
@@ -2042,6 +2042,7 @@ export type SaveApplicationInstanceStateRequest = {
   'id': string;
   'metadata': { 'platformaticVersion': string };
   'services': Array<object>;
+  'scheduler'?: Array<object>;
 }
 
 /**

--- a/clients/control-plane/control-plane.openapi.json
+++ b/clients/control-plane/control-plane.openapi.json
@@ -13582,6 +13582,12 @@
                     "items": {
                       "type": "object"
                     }
+                  },
+                  "scheduler": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
                   }
                 },
                 "additionalProperties": false

--- a/clients/cron/cron-types.d.ts
+++ b/clients/cron/cron-types.d.ts
@@ -1302,6 +1302,9 @@ export type PutWattJobsRequest = {
   'body'?: object | null;
   'headers'?: object | null;
   'applicationId'?: string | null;
+  'source'?: string | null;
+  'scheduleId'?: string | null;
+  'tasks'?: Array<string> | null;
 }
 
 export type PutWattJobsResponseOK = unknown

--- a/clients/cron/cron.mjs
+++ b/clients/cron/cron.mjs
@@ -575,6 +575,8 @@ async function _getIccJobsName (url, request) {
   const responseType = response.headers.get('content-type')?.startsWith('application/json') ? 'json' : 'text'
   let body
   try {
+    // ICC can return an empty or non-JSON error body. Preserve the response
+    // status instead of masking it with a body parsing error.
     body = await response[responseType]()
   } catch {
     body = null

--- a/clients/cron/cron.mjs
+++ b/clients/cron/cron.mjs
@@ -573,10 +573,16 @@ async function _getIccJobsName (url, request) {
     }
   }
   const responseType = response.headers.get('content-type')?.startsWith('application/json') ? 'json' : 'text'
+  let body
+  try {
+    body = await response[responseType]()
+  } catch {
+    body = null
+  }
   return {
     statusCode: response.status,
     headers: headersToJSON(response.headers),
-    body: await response[responseType]()
+    body
   }
 }
 

--- a/clients/cron/cron.openapi.json
+++ b/clients/cron/cron.openapi.json
@@ -9304,6 +9304,21 @@
                   "applicationId": {
                     "type": "string",
                     "nullable": true
+                  },
+                  "source": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "scheduleId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "tasks": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true
                   }
                 },
                 "required": [

--- a/lib/watt.js
+++ b/lib/watt.js
@@ -497,14 +497,27 @@ class Watt {
   }
 
   #configureScheduler (config) {
-    // Disable all watt schedules. We do that because
-    // we will create/update them in ICC, not on watt in memory
+    // Disable all watt schedules when ICC coordinates them centrally
+    // ('external' mode): the jobs are registered and triggered by ICC, so
+    // running them locally would cause concurrent executions across pods.
+    // Older ICC versions don't report a scheduler mode but still register and
+    // trigger the jobs, so we keep disabling for backward compatibility.
+    // In 'local' mode ICC coordination is off and the jobs run locally.
+    const mode = this.#instanceConfig?.scheduler?.mode ?? 'external'
+    if (mode !== 'external') {
+      return
+    }
+
     if (config.scheduler) {
       config.scheduler = config.scheduler.map((scheduler) => ({
         ...scheduler,
         enabled: false
       }))
     }
+  }
+
+  getOriginalSchedulerConfig () {
+    return this.#originalConfig?.scheduler ?? []
   }
 
   async #configureServices (runtime) {

--- a/lib/watt.js
+++ b/lib/watt.js
@@ -501,6 +501,7 @@ class Watt {
   #configureScheduler (config) {
     const { Runtime } = this.#require('@platformatic/runtime')
     if (typeof Runtime?.prototype?.pauseSchedulerJob === 'function') {
+      this.#logger.debug?.('Runtime scheduler controls available, preserving scheduler configuration')
       return
     }
 
@@ -508,6 +509,7 @@ class Watt {
       return
     }
 
+    this.#logger.debug?.('Runtime scheduler controls unavailable, disabling configured jobs for ICC compatibility')
     if (config.scheduler) {
       config.scheduler = config.scheduler.map((scheduler) => ({
         ...scheduler,
@@ -537,11 +539,19 @@ class Watt {
 
     const jobs = await runtime.getScheduler()
 
-    await Promise.all(
-      jobs
-        .filter(job => !job.paused)
-        .map(job => runtime.pauseSchedulerJob(job.name))
+    const activeJobs = jobs.filter(job => !job.paused)
+    const results = await Promise.allSettled(
+      activeJobs.map(job => runtime.pauseSchedulerJob(job.name))
     )
+
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'rejected') {
+        this.#logger.warn(
+          { err: ensureLoggableError(result.reason), job: activeJobs[index].name },
+          'Failed to pause runtime scheduler job for ICC coordination'
+        )
+      }
+    }
 
     this.#logger.info({ jobs: jobs.map(job => job.name) }, 'Runtime scheduler jobs paused for ICC coordination')
   }

--- a/lib/watt.js
+++ b/lib/watt.js
@@ -57,6 +57,7 @@ class Watt {
       this.runtime = await this.#createRuntime()
       this.#logger.info('Starting runtime -WATT')
       await this.runtime.start()
+      await this.#applySchedulerMode(this.runtime)
       await this.updateSharedContext(this.#sharedContext)
       this.#logger.info('Runtime started')
     } catch (err) {
@@ -186,6 +187,7 @@ class Watt {
 
     try {
       await runtime.init()
+      await this.#applySchedulerMode(runtime)
     } catch (e) {
       await runtime.close()
       throw e
@@ -497,14 +499,12 @@ class Watt {
   }
 
   #configureScheduler (config) {
-    // Disable all watt schedules when ICC coordinates them centrally
-    // ('external' mode): the jobs are registered and triggered by ICC, so
-    // running them locally would cause concurrent executions across pods.
-    // Older ICC versions don't report a scheduler mode but still register and
-    // trigger the jobs, so we keep disabling for backward compatibility.
-    // In 'local' mode ICC coordination is off and the jobs run locally.
-    const mode = this.#instanceConfig?.scheduler?.mode ?? 'external'
-    if (mode !== 'external') {
+    const { Runtime } = this.#require('@platformatic/runtime')
+    if (typeof Runtime?.prototype?.pauseSchedulerJob === 'function') {
+      return
+    }
+
+    if (!this.#env.PLT_ICC_URL) {
       return
     }
 
@@ -518,6 +518,32 @@ class Watt {
 
   getOriginalSchedulerConfig () {
     return this.#originalConfig?.scheduler ?? []
+  }
+
+  async applySchedulerMode () {
+    await this.#applySchedulerMode(this.runtime)
+  }
+
+  async #applySchedulerMode (runtime) {
+    if (typeof runtime?.getScheduler !== 'function' ||
+        typeof runtime.pauseSchedulerJob !== 'function' ||
+        typeof runtime.resumeSchedulerJob !== 'function') {
+      return
+    }
+
+    if (!this.#env.PLT_ICC_URL) {
+      return
+    }
+
+    const jobs = await runtime.getScheduler()
+
+    await Promise.all(
+      jobs
+        .filter(job => !job.paused)
+        .map(job => runtime.pauseSchedulerJob(job.name))
+    )
+
+    this.#logger.info({ jobs: jobs.map(job => job.name) }, 'Runtime scheduler jobs paused for ICC coordination')
   }
 
   async #configureServices (runtime) {

--- a/plugins/metadata.js
+++ b/plugins/metadata.js
@@ -56,16 +56,6 @@ async function metadata (app, _opts) {
           }
         }
 
-        // Report the cron jobs defined in the runtime (scheduler config and
-        // application-level scheduled tasks), so that ICC can register and
-        // coordinate them centrally. Failures must not prevent the state report.
-        let scheduler = null
-        try {
-          scheduler = await app.collectSchedulerJobs()
-        } catch (error) {
-          app.log.warn(error, 'Failed to collect the scheduler jobs, not reporting them')
-        }
-
         try {
           // There is a better way? We need to set the default headers for the client
           // every time, because the token might be expired
@@ -75,7 +65,6 @@ async function metadata (app, _opts) {
             id: app.instanceId,
             services,
             metadata: runtimeMetadata,
-            ...(scheduler ? { scheduler } : {})
           }, {
             headers: await app.getAuthorizationHeaders()
           })

--- a/plugins/metadata.js
+++ b/plugins/metadata.js
@@ -56,6 +56,13 @@ async function metadata (app, _opts) {
           }
         }
 
+        let scheduler
+        try {
+          scheduler = await app.collectSchedulerJobs()
+        } catch (error) {
+          app.log.warn(error, 'Failed to collect scheduler jobs, not reporting them')
+        }
+
         try {
           // There is a better way? We need to set the default headers for the client
           // every time, because the token might be expired
@@ -65,6 +72,7 @@ async function metadata (app, _opts) {
             id: app.instanceId,
             services,
             metadata: runtimeMetadata,
+            ...(scheduler ? { scheduler } : {})
           }, {
             headers: await app.getAuthorizationHeaders()
           })

--- a/plugins/metadata.js
+++ b/plugins/metadata.js
@@ -56,6 +56,16 @@ async function metadata (app, _opts) {
           }
         }
 
+        // Report the cron jobs defined in the runtime (scheduler config and
+        // application-level scheduled tasks), so that ICC can register and
+        // coordinate them centrally. Failures must not prevent the state report.
+        let scheduler = null
+        try {
+          scheduler = await app.collectSchedulerJobs()
+        } catch (error) {
+          app.log.warn(error, 'Failed to collect the scheduler jobs, not reporting them')
+        }
+
         try {
           // There is a better way? We need to set the default headers for the client
           // every time, because the token might be expired
@@ -64,7 +74,8 @@ async function metadata (app, _opts) {
           await controlPlaneClient.saveApplicationInstanceState({
             id: app.instanceId,
             services,
-            metadata: runtimeMetadata
+            metadata: runtimeMetadata,
+            ...(scheduler ? { scheduler } : {})
           }, {
             headers: await app.getAuthorizationHeaders()
           })

--- a/plugins/scheduler.js
+++ b/plugins/scheduler.js
@@ -9,7 +9,7 @@ async function scheduler (app, _opts) {
       return runtime.getScheduler()
     }
 
-    // Older runtimes: use the original configuration, since the runtime one
+    // Legacy compatibility path: use the original configuration, since the runtime one
     // has been disabled by the config patch (see Watt#configureScheduler)
     const jobs = app.watt.getOriginalSchedulerConfig?.() ?? []
     return jobs
@@ -38,9 +38,14 @@ async function scheduler (app, _opts) {
 
     app.log.info({ name, source }, 'Executing scheduled job triggered by ICC')
 
-    // Newer runtimes own both configured and application-level jobs.
+    // Runtime-managed jobs, including application-level tasks, do not need a
+    // callback URL. Legacy config jobs fall back to their callback below.
     if (typeof runtime.runSchedulerJob === 'function') {
       return runtime.runSchedulerJob(name)
+    }
+
+    if (source === 'application') {
+      throw new Error(`Cannot execute application scheduled job "${name}": runtime scheduler controls are unavailable`)
     }
 
     if (!callbackUrl) {
@@ -82,8 +87,8 @@ async function scheduler (app, _opts) {
       return
     }
 
-    // Register jobs directly on the cron service. Config jobs retain their
-    // callbacks; application jobs are mapped by new ICC versions to Main.
+    // Legacy ICC integration path: the current API exposes one PUT endpoint
+    // per job. Newer ICC versions register application jobs from state.
     try {
       const applicationId = app.instanceConfig?.applicationId
       const { default: build, setDefaultHeaders } = await import('../clients/cron/cron.mjs')

--- a/plugins/scheduler.js
+++ b/plugins/scheduler.js
@@ -1,28 +1,12 @@
 import { request } from 'undici'
 
 async function scheduler (app, _opts) {
-  // Collects the cron jobs defined in the watt runtime: the `scheduler`
-  // configuration plus the application-level scheduled tasks (e.g. Nitro
-  // scheduled tasks) when the runtime is able to detect them.
+  // Collects configured and application-level jobs owned by the runtime.
   async function collectSchedulerJobs () {
     const runtime = app.watt.runtime
 
-    // Newer runtimes expose the full scheduler status, including scheduled
-    // tasks detected inside the applications (source: 'nitro', ...)
     if (typeof runtime.getScheduler === 'function') {
-      const jobs = await runtime.getScheduler()
-      return jobs.map((job) => ({
-        name: job.name,
-        cron: job.cron,
-        callbackUrl: job.callbackUrl ?? null,
-        method: job.method ?? 'GET',
-        headers: job.headers ?? {},
-        body: job.body ?? {},
-        maxRetries: job.maxRetries ?? 3,
-        source: job.source ?? 'config',
-        applicationId: job.applicationId ?? null,
-        taskName: job.taskName ?? null
-      }))
+      return runtime.getScheduler()
     }
 
     // Older runtimes: use the original configuration, since the runtime one
@@ -42,35 +26,6 @@ async function scheduler (app, _opts) {
       }))
   }
 
-  // Switches the scheduler of the applications defining their own scheduled
-  // tasks (e.g. Nitro) between local execution and external coordination.
-  // Only supported by newer runtimes.
-  async function configureApplicationSchedulers (mode) {
-    const runtime = app.watt.runtime
-    if (typeof runtime.setApplicationSchedulerMode !== 'function') {
-      return
-    }
-
-    const jobs = await collectSchedulerJobs()
-    const applicationIds = [...new Set(
-      jobs
-        .filter((job) => job.source !== 'config' && job.applicationId)
-        .map((job) => job.applicationId)
-    )]
-
-    for (const applicationId of applicationIds) {
-      try {
-        await runtime.setApplicationSchedulerMode(applicationId, mode)
-        app.log.info({ applicationId, mode }, 'Application scheduler mode updated')
-      } catch (error) {
-        app.log.warn(
-          { err: error, applicationId },
-          'Cannot switch the application scheduler mode. If this is a Nuxt application, make sure it uses the @platformatic/nuxt/scheduler module.'
-        )
-      }
-    }
-  }
-
   // Executes a job triggered centrally by ICC (run-scheduled-job command).
   // The job runs in this pod only: ICC dispatches each tick to a single pod.
   async function runScheduledJob (params = {}) {
@@ -83,8 +38,8 @@ async function scheduler (app, _opts) {
 
     app.log.info({ name, source }, 'Executing scheduled job triggered by ICC')
 
-    // Newer runtimes execute configured jobs natively (including retries)
-    if (source === 'config' && typeof runtime.runSchedulerJob === 'function') {
+    // Newer runtimes own both configured and application-level jobs.
+    if (typeof runtime.runSchedulerJob === 'function') {
       return runtime.runSchedulerJob(name)
     }
 
@@ -127,24 +82,8 @@ async function scheduler (app, _opts) {
       return
     }
 
-    const mode = app.instanceConfig?.scheduler?.mode
-
-    if (mode === 'local') {
-      // ICC cron coordination is disabled: the jobs run locally in each pod
-      app.log.info('ICC scheduler coordination is disabled, jobs will run locally')
-      return
-    }
-
-    if (mode === 'external') {
-      // The control-plane registers the jobs centrally from the state report
-      // (see sendMetadata). The runtime config jobs are already disabled at
-      // startup, here we silence the application-level schedulers too.
-      await configureApplicationSchedulers('external')
-      app.log.info('Scheduler coordination delegated to ICC')
-      return
-    }
-
-    // Older ICC versions: register each job directly on the cron service
+    // Register jobs directly on the cron service. Config jobs retain their
+    // callbacks; application jobs are mapped by new ICC versions to Main.
     try {
       const applicationId = app.instanceConfig?.applicationId
       const { default: build, setDefaultHeaders } = await import('../clients/cron/cron.mjs')
@@ -157,36 +96,61 @@ async function scheduler (app, _opts) {
       const cronClient = build(cronUrl)
       setDefaultHeaders(await app.getAuthorizationHeaders())
 
-      const jobs = (await collectSchedulerJobs()).filter((job) => job.source === 'config')
+      const jobs = await collectSchedulerJobs()
+      const configJobs = jobs.filter((job) => job.source === 'config')
+      const applicationJobs = jobs.filter((job) => job.source === 'application')
 
-      const saveJobs = []
-      for (const job of jobs) {
+      async function saveJob (job) {
         const iccJob = {
           name: job.name,
-          callbackUrl: job.callbackUrl,
-          schedule: job.cron, // unfortunately, the ICC API uses `schedule` instead of `cron`
+          schedule: job.cron,
           method: job.method,
           maxRetries: job.maxRetries,
           applicationId
         }
-        if (job.headers && Object.keys(job.headers).length > 0) {
-          iccJob.headers = job.headers
+
+        if (job.source === 'application') {
+          iccJob.source = job.source
+          iccJob.scheduleId = job.scheduleId
+          iccJob.tasks = job.tasks
+        } else {
+          iccJob.callbackUrl = job.callbackUrl
+          if (job.headers && Object.keys(job.headers).length > 0) {
+            iccJob.headers = job.headers
+          }
+          if (job.body && (typeof job.body === 'string' ? job.body.length > 0 : Object.keys(job.body).length > 0)) {
+            iccJob.body = job.body
+          }
         }
-        if (job.body && (typeof job.body === 'string' ? job.body.length > 0 : Object.keys(job.body).length > 0)) {
-          iccJob.body = job.body
+
+        const result = await cronClient.putWattJobs(iccJob)
+        if (result.statusCode >= 400) {
+          const error = new Error(`ICC returned HTTP ${result.statusCode} while saving job "${job.name}"`)
+          error.statusCode = result.statusCode
+          throw error
         }
-        saveJobs.push(cronClient.putWattJobs(iccJob))
       }
-      const result = await Promise.allSettled(saveJobs)
-      const errors = result.filter((job) => job.status === 'rejected')
-      if (errors.length > 0) {
-        app.log.error(errors, 'Failed to save jobs in ICC')
-        throw new AggregateError('Failed to save jobs in ICC', { cause: errors.map(job => job.reason) })
+
+      for (const job of configJobs) {
+        await saveJob(job)
+      }
+
+      for (const [index, job] of applicationJobs.entries()) {
+        try {
+          await saveJob(job)
+        } catch (error) {
+          if (index === 0 && error.statusCode === 400) {
+            app.log.warn('ICC does not support application scheduler jobs, skipping application registrations')
+            break
+          }
+          throw error
+        }
       }
 
       app.log.info('Scheduler configured')
     } catch (error) {
       app.log.error(error, 'Failed in configuring watt jobs in ICC')
+      throw error
     }
   }
 

--- a/plugins/scheduler.js
+++ b/plugins/scheduler.js
@@ -1,4 +1,125 @@
+import { request } from 'undici'
+
 async function scheduler (app, _opts) {
+  // Collects the cron jobs defined in the watt runtime: the `scheduler`
+  // configuration plus the application-level scheduled tasks (e.g. Nitro
+  // scheduled tasks) when the runtime is able to detect them.
+  async function collectSchedulerJobs () {
+    const runtime = app.watt.runtime
+
+    // Newer runtimes expose the full scheduler status, including scheduled
+    // tasks detected inside the applications (source: 'nitro', ...)
+    if (typeof runtime.getScheduler === 'function') {
+      const jobs = await runtime.getScheduler()
+      return jobs.map((job) => ({
+        name: job.name,
+        cron: job.cron,
+        callbackUrl: job.callbackUrl ?? null,
+        method: job.method ?? 'GET',
+        headers: job.headers ?? {},
+        body: job.body ?? {},
+        maxRetries: job.maxRetries ?? 3,
+        source: job.source ?? 'config',
+        applicationId: job.applicationId ?? null,
+        taskName: job.taskName ?? null
+      }))
+    }
+
+    // Older runtimes: use the original configuration, since the runtime one
+    // has been disabled by the config patch (see Watt#configureScheduler)
+    const jobs = app.watt.getOriginalSchedulerConfig?.() ?? []
+    return jobs
+      .filter((job) => job.enabled !== false)
+      .map((job) => ({
+        name: job.name,
+        cron: job.cron,
+        callbackUrl: job.callbackUrl,
+        method: job.method ?? 'GET',
+        headers: job.headers ?? {},
+        body: job.body ?? {},
+        maxRetries: job.maxRetries ?? 3,
+        source: 'config'
+      }))
+  }
+
+  // Switches the scheduler of the applications defining their own scheduled
+  // tasks (e.g. Nitro) between local execution and external coordination.
+  // Only supported by newer runtimes.
+  async function configureApplicationSchedulers (mode) {
+    const runtime = app.watt.runtime
+    if (typeof runtime.setApplicationSchedulerMode !== 'function') {
+      return
+    }
+
+    const jobs = await collectSchedulerJobs()
+    const applicationIds = [...new Set(
+      jobs
+        .filter((job) => job.source !== 'config' && job.applicationId)
+        .map((job) => job.applicationId)
+    )]
+
+    for (const applicationId of applicationIds) {
+      try {
+        await runtime.setApplicationSchedulerMode(applicationId, mode)
+        app.log.info({ applicationId, mode }, 'Application scheduler mode updated')
+      } catch (error) {
+        app.log.warn(
+          { err: error, applicationId },
+          'Cannot switch the application scheduler mode. If this is a Nuxt application, make sure it uses the @platformatic/nuxt/scheduler module.'
+        )
+      }
+    }
+  }
+
+  // Executes a job triggered centrally by ICC (run-scheduled-job command).
+  // The job runs in this pod only: ICC dispatches each tick to a single pod.
+  async function runScheduledJob (params = {}) {
+    const runtime = app.watt.runtime
+    if (!runtime) {
+      throw new Error('Runtime not started, cannot run scheduled job')
+    }
+
+    const { name, callbackUrl, method = 'GET', headers = {}, body, source = 'config' } = params
+
+    app.log.info({ name, source }, 'Executing scheduled job triggered by ICC')
+
+    // Newer runtimes execute configured jobs natively (including retries)
+    if (source === 'config' && typeof runtime.runSchedulerJob === 'function') {
+      return runtime.runSchedulerJob(name)
+    }
+
+    if (!callbackUrl) {
+      throw new Error(`Cannot execute scheduled job "${name}": no callback URL`)
+    }
+
+    const url = new URL(callbackUrl)
+    const bodyString = body == null || typeof body === 'string' ? body : JSON.stringify(body)
+
+    let statusCode
+    if (url.hostname.endsWith('.plt.local')) {
+      // Internal mesh URL: route the request through the runtime
+      const applicationId = url.hostname.slice(0, -'.plt.local'.length)
+      const res = await runtime.inject(applicationId, {
+        method,
+        url: `${url.pathname}${url.search}`,
+        headers,
+        body: bodyString ?? undefined
+      })
+      statusCode = res.statusCode
+    } else {
+      const res = await request(callbackUrl, { method, headers, body: bodyString ?? undefined })
+      await res.body.dump()
+      statusCode = res.statusCode
+    }
+
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`Scheduled job "${name}" failed with HTTP ${statusCode}`)
+    }
+
+    app.log.info({ name, statusCode }, 'Scheduled job executed')
+    return { name, statusCode }
+  }
+
   async function sendSchedulerInfo () {
     // Skip scheduler configuration if ICC is not configured
     if (!app.env.PLT_ICC_URL) {
@@ -6,10 +127,26 @@ async function scheduler (app, _opts) {
       return
     }
 
+    const mode = app.instanceConfig?.scheduler?.mode
+
+    if (mode === 'local') {
+      // ICC cron coordination is disabled: the jobs run locally in each pod
+      app.log.info('ICC scheduler coordination is disabled, jobs will run locally')
+      return
+    }
+
+    if (mode === 'external') {
+      // The control-plane registers the jobs centrally from the state report
+      // (see sendMetadata). The runtime config jobs are already disabled at
+      // startup, here we silence the application-level schedulers too.
+      await configureApplicationSchedulers('external')
+      app.log.info('Scheduler coordination delegated to ICC')
+      return
+    }
+
+    // Older ICC versions: register each job directly on the cron service
     try {
       const applicationId = app.instanceConfig?.applicationId
-      const runtime = app.watt.runtime
-      const config = await runtime.getRuntimeConfig()
       const { default: build, setDefaultHeaders } = await import('../clients/cron/cron.mjs')
 
       const cronUrl = app.instanceConfig?.iccServices?.cron?.url
@@ -20,14 +157,24 @@ async function scheduler (app, _opts) {
       const cronClient = build(cronUrl)
       setDefaultHeaders(await app.getAuthorizationHeaders())
 
-      const jobs = config.scheduler || []
+      const jobs = (await collectSchedulerJobs()).filter((job) => job.source === 'config')
 
       const saveJobs = []
       for (const job of jobs) {
-        const iccJob = { ...job, applicationId }
-        iccJob.schedule = iccJob.cron // unfortunately, the ICC API uses `schedule` instead of `cron`
-        delete iccJob.cron
-        delete iccJob.enabled
+        const iccJob = {
+          name: job.name,
+          callbackUrl: job.callbackUrl,
+          schedule: job.cron, // unfortunately, the ICC API uses `schedule` instead of `cron`
+          method: job.method,
+          maxRetries: job.maxRetries,
+          applicationId
+        }
+        if (job.headers && Object.keys(job.headers).length > 0) {
+          iccJob.headers = job.headers
+        }
+        if (job.body && (typeof job.body === 'string' ? job.body.length > 0 : Object.keys(job.body).length > 0)) {
+          iccJob.body = job.body
+        }
         saveJobs.push(cronClient.putWattJobs(iccJob))
       }
       const result = await Promise.allSettled(saveJobs)
@@ -42,7 +189,10 @@ async function scheduler (app, _opts) {
       app.log.error(error, 'Failed in configuring watt jobs in ICC')
     }
   }
+
   app.sendSchedulerInfo = sendSchedulerInfo
+  app.collectSchedulerJobs = collectSchedulerJobs
+  app.runScheduledJob = runScheduledJob
 }
 
 export default scheduler

--- a/plugins/update.js
+++ b/plugins/update.js
@@ -41,7 +41,25 @@ async function updatePlugin (app) {
       // each tick to exactly one pod of the application, this one.
       if (command === 'run-scheduled-job') {
         app.log.info({ command, job: message.params?.name }, 'Received run-scheduled-job command from ICC')
-        await app.runScheduledJob(message.params ?? {})
+        try {
+          const result = await app.runScheduledJob(message.params ?? {})
+          if (message.requestId) {
+            socket.send(JSON.stringify({
+              requestId: message.requestId,
+              success: result?.success !== false,
+              result
+            }))
+          }
+        } catch (error) {
+          if (message.requestId) {
+            socket.send(JSON.stringify({
+              requestId: message.requestId,
+              success: false,
+              error: { message: error.message, name: error.name }
+            }))
+          }
+          throw error
+        }
         return
       }
 

--- a/plugins/update.js
+++ b/plugins/update.js
@@ -37,6 +37,14 @@ async function updatePlugin (app) {
         return
       }
 
+      // Handle a centrally coordinated cron job execution: ICC dispatches
+      // each tick to exactly one pod of the application, this one.
+      if (command === 'run-scheduled-job') {
+        app.log.info({ command, job: message.params?.name }, 'Received run-scheduled-job command from ICC')
+        await app.runScheduledJob(message.params ?? {})
+        return
+      }
+
       // Handle updates websocket format: { type: '...', topic: '...', data: {...} }
       if (!topic || !type) {
         app.log.warn({ message }, 'Received invalid message from updates websocket')

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  msgpackr-extract: true
+  protobufjs: true
+  sharp: true
+  unrs-resolver: true

--- a/test/scheduler-coordination.test.js
+++ b/test/scheduler-coordination.test.js
@@ -88,7 +88,9 @@ test('ICC coordination: should disable local jobs and register config jobs direc
 
   // The jobs are reported in the application state
   assert.ok(savedState, 'the state should have been reported')
-  assert.strictEqual(savedState.scheduler, undefined)
+  assert.ok(Array.isArray(savedState.scheduler))
+  assert.strictEqual(savedState.scheduler[0].name, 'test')
+  assert.strictEqual(savedState.scheduler[0].source, 'config')
 })
 
 test('ICC coordination: should disable local jobs regardless of scheduler mode', async (t) => {
@@ -159,7 +161,7 @@ test('runtime scheduler ownership always pauses jobs when ICC is configured', as
       PLT_APP_DIR: join(__dirname, 'fixtures', 'runtime-scheduler'),
       PLT_ICC_URL: 'http://localhost:3000'
     },
-    log: { info: () => {} },
+    log: { info: () => {}, debug: () => {}, warn: () => {} },
     instanceConfig,
     instanceId: 'test-pod-123'
   })
@@ -179,6 +181,36 @@ test('runtime scheduler ownership always pauses jobs when ICC is configured', as
 
   await watt.applySchedulerMode()
   assert.deepStrictEqual(jobs.map(job => job.paused), [true, true])
+})
+
+test('runtime scheduler ownership continues when pausing one job fails', async () => {
+  const jobs = [
+    { name: 'failed', paused: false },
+    { name: 'paused', paused: false }
+  ]
+  const watt = new Watt({
+    env: {
+      PLT_APP_DIR: join(__dirname, 'fixtures', 'runtime-scheduler'),
+      PLT_ICC_URL: 'http://localhost:3000'
+    },
+    log: { info: () => {}, debug: () => {}, warn: () => {} },
+    instanceConfig: {},
+    instanceId: 'test-pod-123'
+  })
+
+  watt.runtime = {
+    getScheduler: () => jobs,
+    pauseSchedulerJob: async name => {
+      if (name === 'failed') {
+        throw new Error('pause failed')
+      }
+      jobs[1].paused = true
+    },
+    resumeSchedulerJob: async () => {}
+  }
+
+  await watt.applySchedulerMode()
+  assert.deepStrictEqual(jobs.map(job => job.paused), [false, true])
 })
 
 function setupMockIccServer (wss) {
@@ -280,7 +312,7 @@ test('run-scheduled-job: should route legacy internal callbacks through the runt
   assert.strictEqual(injected[0].body, '{"scheduledTime":1}')
 })
 
-test('run-scheduled-job: should use native runtime execution for application jobs', async (t) => {
+test('run-scheduled-job: should use native runtime execution for application tasks without callbacks', async (t) => {
   const app = createMockApp(0)
 
   const executed = []
@@ -295,6 +327,17 @@ test('run-scheduled-job: should use native runtime execution for application job
 
   assert.deepStrictEqual(executed, ['frontend:0'])
   assert.deepStrictEqual(result, { name: 'frontend:0', success: true })
+})
+
+test('run-scheduled-job: should reject application tasks without runtime support', async (t) => {
+  const app = createMockApp(0)
+
+  await schedulerPlugin(app)
+
+  await assert.rejects(
+    app.runScheduledJob({ name: 'frontend:0', source: 'application' }),
+    /runtime scheduler controls are unavailable/
+  )
 })
 
 test('run-scheduled-job: should fail on non-2xx callback responses', async (t) => {

--- a/test/scheduler-coordination.test.js
+++ b/test/scheduler-coordination.test.js
@@ -7,6 +7,7 @@ import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import WebSocket from 'ws'
 import { start } from '../index.js'
+import Watt from '../lib/watt.js'
 import schedulerPlugin from '../plugins/scheduler.js'
 import updatePlugin from '../plugins/update.js'
 
@@ -33,7 +34,7 @@ function controlPlaneResponseWithMode (applicationId, applicationName, mode) {
   })
 }
 
-test('external mode: should disable local jobs, skip legacy registration and report the jobs in the state', async (t) => {
+test('ICC coordination: should disable local jobs and register config jobs directly', async (t) => {
   const applicationName = 'test-app'
   const applicationId = randomUUID()
   const applicationPath = join(__dirname, 'fixtures', 'runtime-scheduler')
@@ -66,25 +67,31 @@ test('external mode: should disable local jobs, skip legacy registration and rep
     await icc.close()
   })
 
-  // The local scheduler triggers are disabled
+  // The local scheduler triggers are disabled on released runtimes and paused
+  // on runtimes exposing scheduler control.
   const config = await app.watt.runtime.getRuntimeConfig()
-  assert.strictEqual(config.scheduler[0].enabled, false)
+  if (typeof app.watt.runtime.pauseSchedulerJob === 'function') {
+    assert.notStrictEqual(config.scheduler[0].enabled, false)
+    assert.strictEqual(app.watt.runtime.getScheduler()[0].paused, true)
+  } else {
+    assert.strictEqual(config.scheduler[0].enabled, false)
+  }
 
-  // The legacy per-job registration is skipped: the control-plane
-  // registers the jobs centrally from the state report
-  assert.strictEqual(savedWattJob, null)
+  assert.deepStrictEqual(savedWattJob, {
+    name: 'test',
+    schedule: '*/5 * * * *',
+    method: 'GET',
+    maxRetries: 3,
+    applicationId,
+    callbackUrl: 'http://localhost:3000'
+  })
 
   // The jobs are reported in the application state
   assert.ok(savedState, 'the state should have been reported')
-  assert.ok(Array.isArray(savedState.scheduler), 'the state should include the scheduler jobs')
-  assert.strictEqual(savedState.scheduler.length, 1)
-  assert.strictEqual(savedState.scheduler[0].name, 'test')
-  assert.strictEqual(savedState.scheduler[0].cron, '*/5 * * * *')
-  assert.strictEqual(savedState.scheduler[0].callbackUrl, 'http://localhost:3000')
-  assert.strictEqual(savedState.scheduler[0].source, 'config')
+  assert.strictEqual(savedState.scheduler, undefined)
 })
 
-test('local mode: should keep the local jobs running and skip any registration', async (t) => {
+test('ICC coordination: should disable local jobs regardless of scheduler mode', async (t) => {
   const applicationName = 'test-app'
   const applicationId = randomUUID()
   const applicationPath = join(__dirname, 'fixtures', 'runtime-scheduler')
@@ -113,12 +120,11 @@ test('local mode: should keep the local jobs running and skip any registration',
     await icc.close()
   })
 
-  // ICC coordination is disabled: the local scheduler stays enabled
+  // ICC coordination always disables local execution.
   const config = await app.watt.runtime.getRuntimeConfig()
-  assert.notStrictEqual(config.scheduler[0].enabled, false)
+  assert.strictEqual(config.scheduler[0].enabled, false)
 
-  // No registration happens: the jobs run locally in each pod
-  assert.strictEqual(savedWattJob, null)
+  assert.ok(savedWattJob)
 })
 
 function createMockApp (port) {
@@ -135,9 +141,45 @@ function createMockApp (port) {
       PLT_ICC_URL: `http://localhost:${port}`,
       PLT_UPDATES_RECONNECT_INTERVAL_SEC: 1
     },
-    watt: { runtime: {} }
+    watt: {
+      runtime: {},
+      applySchedulerMode: async () => {}
+    }
   }
 }
+
+test('runtime scheduler ownership always pauses jobs when ICC is configured', async () => {
+  const instanceConfig = {}
+  const jobs = [
+    { name: 'configured', paused: false },
+    { name: 'frontend:0', paused: false }
+  ]
+  const watt = new Watt({
+    env: {
+      PLT_APP_DIR: join(__dirname, 'fixtures', 'runtime-scheduler'),
+      PLT_ICC_URL: 'http://localhost:3000'
+    },
+    log: { info: () => {} },
+    instanceConfig,
+    instanceId: 'test-pod-123'
+  })
+
+  watt.runtime = {
+    getScheduler: () => jobs,
+    pauseSchedulerJob: async name => {
+      jobs.find(job => job.name === name).paused = true
+    },
+    resumeSchedulerJob: async name => {
+      jobs.find(job => job.name === name).paused = false
+    }
+  }
+
+  await watt.applySchedulerMode()
+  assert.deepStrictEqual(jobs.map(job => job.paused), [true, true])
+
+  await watt.applySchedulerMode()
+  assert.deepStrictEqual(jobs.map(job => job.paused), [true, true])
+})
 
 function setupMockIccServer (wss) {
   let ws = null
@@ -190,6 +232,7 @@ test('run-scheduled-job: should execute the job callback when triggered over the
 
   getWs().send(JSON.stringify({
     command: 'run-scheduled-job',
+    requestId: 'job-request-1',
     params: {
       name: 'cleanup',
       callbackUrl: `http://127.0.0.1:${target.address().port}/cleanup`,
@@ -200,10 +243,17 @@ test('run-scheduled-job: should execute the job callback when triggered over the
 
   await requestReceived
 
+  const response = JSON.parse((await once(getWs(), 'message'))[0].toString())
+  assert.deepStrictEqual(response, {
+    requestId: 'job-request-1',
+    success: true,
+    result: { name: 'cleanup', statusCode: 200 }
+  })
+
   assert.deepStrictEqual(receivedRequests, [{ method: 'POST', url: '/cleanup' }])
 })
 
-test('run-scheduled-job: should route internal mesh callbacks through the runtime', async (t) => {
+test('run-scheduled-job: should route legacy internal callbacks through the runtime', async (t) => {
   const app = createMockApp(0)
 
   const injected = []
@@ -215,22 +265,22 @@ test('run-scheduled-job: should route internal mesh callbacks through the runtim
   await schedulerPlugin(app)
 
   const result = await app.runScheduledJob({
-    name: 'frontend:db:cleanup',
-    callbackUrl: 'http://frontend.plt.local/_platformatic/tasks/db:cleanup',
+    name: 'cleanup',
+    callbackUrl: 'http://frontend.plt.local/cleanup',
     method: 'POST',
-    source: 'nitro',
+    source: 'config',
     body: { scheduledTime: 1 }
   })
 
-  assert.deepStrictEqual(result, { name: 'frontend:db:cleanup', statusCode: 200 })
+  assert.deepStrictEqual(result, { name: 'cleanup', statusCode: 200 })
   assert.strictEqual(injected.length, 1)
   assert.strictEqual(injected[0].applicationId, 'frontend')
   assert.strictEqual(injected[0].method, 'POST')
-  assert.strictEqual(injected[0].url, '/_platformatic/tasks/db:cleanup')
+  assert.strictEqual(injected[0].url, '/cleanup')
   assert.strictEqual(injected[0].body, '{"scheduledTime":1}')
 })
 
-test('run-scheduled-job: should use the native runtime execution for config jobs when available', async (t) => {
+test('run-scheduled-job: should use native runtime execution for application jobs', async (t) => {
   const app = createMockApp(0)
 
   const executed = []
@@ -241,10 +291,10 @@ test('run-scheduled-job: should use the native runtime execution for config jobs
 
   await schedulerPlugin(app)
 
-  const result = await app.runScheduledJob({ name: 'cleanup', source: 'config' })
+  const result = await app.runScheduledJob({ name: 'frontend:0', source: 'application' })
 
-  assert.deepStrictEqual(executed, ['cleanup'])
-  assert.deepStrictEqual(result, { name: 'cleanup', success: true })
+  assert.deepStrictEqual(executed, ['frontend:0'])
+  assert.deepStrictEqual(result, { name: 'frontend:0', success: true })
 })
 
 test('run-scheduled-job: should fail on non-2xx callback responses', async (t) => {
@@ -258,7 +308,7 @@ test('run-scheduled-job: should fail on non-2xx callback responses', async (t) =
     app.runScheduledJob({
       name: 'failing',
       callbackUrl: 'http://frontend.plt.local/failing',
-      source: 'nitro'
+      source: 'config'
     }),
     /Scheduled job "failing" failed with HTTP 500/
   )
@@ -277,13 +327,12 @@ test('collectSchedulerJobs: should use the runtime scheduler status when availab
       paused: false
     },
     {
-      name: 'frontend:db:cleanup',
+      name: 'frontend:0',
       cron: '* * * * *',
-      callbackUrl: 'http://frontend.plt.local/_platformatic/tasks/db:cleanup',
-      method: 'POST',
-      source: 'nitro',
+      source: 'application',
       applicationId: 'frontend',
-      taskName: 'db:cleanup'
+      scheduleId: '0',
+      tasks: ['db:cleanup']
     }
   ])
 
@@ -294,29 +343,78 @@ test('collectSchedulerJobs: should use the runtime scheduler status when availab
   assert.strictEqual(jobs.length, 2)
   assert.strictEqual(jobs[0].name, 'cleanup')
   assert.strictEqual(jobs[0].source, 'config')
-  assert.strictEqual(jobs[1].name, 'frontend:db:cleanup')
-  assert.strictEqual(jobs[1].source, 'nitro')
+  assert.strictEqual(jobs[1].name, 'frontend:0')
+  assert.strictEqual(jobs[1].source, 'application')
   assert.strictEqual(jobs[1].applicationId, 'frontend')
-  assert.strictEqual(jobs[1].taskName, 'db:cleanup')
+  assert.strictEqual(jobs[1].scheduleId, '0')
+  assert.deepStrictEqual(jobs[1].tasks, ['db:cleanup'])
 })
 
-test('external mode: should switch the application-level schedulers to external', async (t) => {
+test('sendSchedulerInfo: should register config jobs before skipping application jobs on old ICC', async () => {
   const app = createMockApp(0)
-
+  app.instanceConfig.iccServices = { cron: { url: 'http://cron.local' } }
   app.watt.runtime.getScheduler = async () => ([
-    { name: 'cleanup', cron: '0 * * * *', callbackUrl: 'http://x.plt.local/y', source: 'config' },
-    { name: 'frontend:log', cron: '* * * * *', source: 'nitro', applicationId: 'frontend', taskName: 'log' },
-    { name: 'frontend:sync', cron: '* * * * *', source: 'nitro', applicationId: 'frontend', taskName: 'sync' }
+    {
+      name: 'config-job',
+      cron: '*/5 * * * *',
+      callbackUrl: 'http://service.plt.local/run',
+      source: 'config'
+    },
+    {
+      name: 'application:0',
+      cron: '* * * * *',
+      source: 'application',
+      applicationId: 'frontend',
+      scheduleId: '0',
+      tasks: ['cleanup']
+    },
+    {
+      name: 'application:1',
+      cron: '0 * * * *',
+      source: 'application',
+      applicationId: 'frontend',
+      scheduleId: '1',
+      tasks: ['sync']
+    }
   ])
 
-  const modeChanges = []
-  app.watt.runtime.setApplicationSchedulerMode = async (applicationId, mode) => {
-    modeChanges.push({ applicationId, mode })
+  const requests = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (_url, options) => {
+    requests.push(JSON.parse(options.body))
+    const status = requests.length === 2 ? 400 : 200
+    return {
+      status,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => '',
+      json: async () => ({ error: 'unsupported' })
+    }
+  }
+
+  try {
+    await schedulerPlugin(app)
+    await app.sendSchedulerInfo()
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  assert.strictEqual(requests.length, 2)
+  assert.strictEqual(requests[0].callbackUrl, 'http://service.plt.local/run')
+  assert.strictEqual(requests[1].callbackUrl, undefined)
+  assert.deepStrictEqual(requests[1].tasks, ['cleanup'])
+})
+
+test('without ICC: should not apply runtime scheduler ownership', async (t) => {
+  const app = createMockApp(0)
+  app.env.PLT_ICC_URL = undefined
+
+  let applications = 0
+  app.watt.applySchedulerMode = async () => {
+    applications++
   }
 
   await schedulerPlugin(app)
   await app.sendSchedulerInfo()
 
-  // One switch per application, even with multiple tasks
-  assert.deepStrictEqual(modeChanges, [{ applicationId: 'frontend', mode: 'external' }])
+  assert.strictEqual(applications, 0)
 })

--- a/test/scheduler-coordination.test.js
+++ b/test/scheduler-coordination.test.js
@@ -1,0 +1,322 @@
+import assert from 'node:assert'
+import { randomUUID } from 'node:crypto'
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import { join, dirname } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import WebSocket from 'ws'
+import { start } from '../index.js'
+import schedulerPlugin from '../plugins/scheduler.js'
+import updatePlugin from '../plugins/update.js'
+
+import {
+  setUpEnvironment,
+  startICC,
+  installDeps
+} from './helper.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+function controlPlaneResponseWithMode (applicationId, applicationName, mode) {
+  return () => ({
+    applicationId,
+    applicationName,
+    config: {},
+    scheduler: { mode },
+    iccServices: {
+      cron: { url: 'http://127.0.0.1:3000/cron' },
+      compliance: { url: 'http://127.0.0.1:3000/compliance' },
+      scaler: { url: 'http://127.0.0.1:3000/scaler' }
+    }
+  })
+}
+
+test('external mode: should disable local jobs, skip legacy registration and report the jobs in the state', async (t) => {
+  const applicationName = 'test-app'
+  const applicationId = randomUUID()
+  const applicationPath = join(__dirname, 'fixtures', 'runtime-scheduler')
+
+  await installDeps(t, applicationPath)
+
+  let savedWattJob = null
+  let savedState = null
+  const icc = await startICC(t, {
+    applicationId,
+    applicationName,
+    controlPlaneResponse: controlPlaneResponseWithMode(applicationId, applicationName, 'external'),
+    saveWattJob: (job) => {
+      savedWattJob = job
+    },
+    saveApplicationInstanceState: ({ state }) => {
+      savedState = state
+    }
+  })
+
+  setUpEnvironment({
+    PLT_APP_NAME: applicationName,
+    PLT_APP_DIR: applicationPath,
+    PLT_ICC_URL: 'http://127.0.0.1:3000'
+  })
+  const app = await start()
+
+  t.after(async () => {
+    await app.close()
+    await icc.close()
+  })
+
+  // The local scheduler triggers are disabled
+  const config = await app.watt.runtime.getRuntimeConfig()
+  assert.strictEqual(config.scheduler[0].enabled, false)
+
+  // The legacy per-job registration is skipped: the control-plane
+  // registers the jobs centrally from the state report
+  assert.strictEqual(savedWattJob, null)
+
+  // The jobs are reported in the application state
+  assert.ok(savedState, 'the state should have been reported')
+  assert.ok(Array.isArray(savedState.scheduler), 'the state should include the scheduler jobs')
+  assert.strictEqual(savedState.scheduler.length, 1)
+  assert.strictEqual(savedState.scheduler[0].name, 'test')
+  assert.strictEqual(savedState.scheduler[0].cron, '*/5 * * * *')
+  assert.strictEqual(savedState.scheduler[0].callbackUrl, 'http://localhost:3000')
+  assert.strictEqual(savedState.scheduler[0].source, 'config')
+})
+
+test('local mode: should keep the local jobs running and skip any registration', async (t) => {
+  const applicationName = 'test-app'
+  const applicationId = randomUUID()
+  const applicationPath = join(__dirname, 'fixtures', 'runtime-scheduler')
+
+  await installDeps(t, applicationPath)
+
+  let savedWattJob = null
+  const icc = await startICC(t, {
+    applicationId,
+    applicationName,
+    controlPlaneResponse: controlPlaneResponseWithMode(applicationId, applicationName, 'local'),
+    saveWattJob: (job) => {
+      savedWattJob = job
+    }
+  })
+
+  setUpEnvironment({
+    PLT_APP_NAME: applicationName,
+    PLT_APP_DIR: applicationPath,
+    PLT_ICC_URL: 'http://127.0.0.1:3000'
+  })
+  const app = await start()
+
+  t.after(async () => {
+    await app.close()
+    await icc.close()
+  })
+
+  // ICC coordination is disabled: the local scheduler stays enabled
+  const config = await app.watt.runtime.getRuntimeConfig()
+  assert.notStrictEqual(config.scheduler[0].enabled, false)
+
+  // No registration happens: the jobs run locally in each pod
+  assert.strictEqual(savedWattJob, null)
+})
+
+function createMockApp (port) {
+  return {
+    log: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} },
+    instanceConfig: {
+      applicationId: 'test-application-id',
+      scheduler: { mode: 'external' }
+    },
+    instanceId: 'test-pod-123',
+    getRuntimeId: () => 'test-runtime-id',
+    getAuthorizationHeaders: async () => ({ Authorization: 'Bearer test-token' }),
+    env: {
+      PLT_ICC_URL: `http://localhost:${port}`,
+      PLT_UPDATES_RECONNECT_INTERVAL_SEC: 1
+    },
+    watt: { runtime: {} }
+  }
+}
+
+function setupMockIccServer (wss) {
+  let ws = null
+
+  const waitForClientSubscription = once(wss, 'connection').then(([socket]) => {
+    ws = socket
+
+    return new Promise((resolve) => {
+      socket.on('message', (data) => {
+        const message = JSON.parse(data.toString())
+
+        if (message.command === 'subscribe' && message.topic === '/config') {
+          socket.send(JSON.stringify({ command: 'ack' }))
+          resolve()
+        }
+      })
+    })
+  })
+
+  return { waitForClientSubscription, getWs: () => ws }
+}
+
+test('run-scheduled-job: should execute the job callback when triggered over the websocket', async (t) => {
+  setUpEnvironment()
+  const port = 14100
+
+  const wss = new WebSocket.Server({ port })
+  t.after(() => wss.close())
+
+  const { waitForClientSubscription, getWs } = setupMockIccServer(wss)
+
+  // The target the job callback should hit
+  const receivedRequests = []
+  let requestResolve
+  const requestReceived = new Promise((resolve) => { requestResolve = resolve })
+  const target = createServer((req, res) => {
+    receivedRequests.push({ method: req.method, url: req.url })
+    res.end('{"ok":true}')
+    requestResolve()
+  })
+  await new Promise((resolve) => target.listen(0, resolve))
+  t.after(() => target.close())
+
+  const app = createMockApp(port)
+  await schedulerPlugin(app)
+  await updatePlugin(app)
+  await app.connectToUpdates()
+  t.after(() => app.closeUpdates())
+  await waitForClientSubscription
+
+  getWs().send(JSON.stringify({
+    command: 'run-scheduled-job',
+    params: {
+      name: 'cleanup',
+      callbackUrl: `http://127.0.0.1:${target.address().port}/cleanup`,
+      method: 'POST',
+      source: 'config'
+    }
+  }))
+
+  await requestReceived
+
+  assert.deepStrictEqual(receivedRequests, [{ method: 'POST', url: '/cleanup' }])
+})
+
+test('run-scheduled-job: should route internal mesh callbacks through the runtime', async (t) => {
+  const app = createMockApp(0)
+
+  const injected = []
+  app.watt.runtime.inject = async (applicationId, params) => {
+    injected.push({ applicationId, ...params })
+    return { statusCode: 200 }
+  }
+
+  await schedulerPlugin(app)
+
+  const result = await app.runScheduledJob({
+    name: 'frontend:db:cleanup',
+    callbackUrl: 'http://frontend.plt.local/_platformatic/tasks/db:cleanup',
+    method: 'POST',
+    source: 'nitro',
+    body: { scheduledTime: 1 }
+  })
+
+  assert.deepStrictEqual(result, { name: 'frontend:db:cleanup', statusCode: 200 })
+  assert.strictEqual(injected.length, 1)
+  assert.strictEqual(injected[0].applicationId, 'frontend')
+  assert.strictEqual(injected[0].method, 'POST')
+  assert.strictEqual(injected[0].url, '/_platformatic/tasks/db:cleanup')
+  assert.strictEqual(injected[0].body, '{"scheduledTime":1}')
+})
+
+test('run-scheduled-job: should use the native runtime execution for config jobs when available', async (t) => {
+  const app = createMockApp(0)
+
+  const executed = []
+  app.watt.runtime.runSchedulerJob = async (name) => {
+    executed.push(name)
+    return { name, success: true }
+  }
+
+  await schedulerPlugin(app)
+
+  const result = await app.runScheduledJob({ name: 'cleanup', source: 'config' })
+
+  assert.deepStrictEqual(executed, ['cleanup'])
+  assert.deepStrictEqual(result, { name: 'cleanup', success: true })
+})
+
+test('run-scheduled-job: should fail on non-2xx callback responses', async (t) => {
+  const app = createMockApp(0)
+
+  app.watt.runtime.inject = async () => ({ statusCode: 500 })
+
+  await schedulerPlugin(app)
+
+  await assert.rejects(
+    app.runScheduledJob({
+      name: 'failing',
+      callbackUrl: 'http://frontend.plt.local/failing',
+      source: 'nitro'
+    }),
+    /Scheduled job "failing" failed with HTTP 500/
+  )
+})
+
+test('collectSchedulerJobs: should use the runtime scheduler status when available', async (t) => {
+  const app = createMockApp(0)
+
+  app.watt.runtime.getScheduler = async () => ([
+    {
+      name: 'cleanup',
+      cron: '0 * * * *',
+      callbackUrl: 'http://service.plt.local/cleanup',
+      method: 'POST',
+      source: 'config',
+      paused: false
+    },
+    {
+      name: 'frontend:db:cleanup',
+      cron: '* * * * *',
+      callbackUrl: 'http://frontend.plt.local/_platformatic/tasks/db:cleanup',
+      method: 'POST',
+      source: 'nitro',
+      applicationId: 'frontend',
+      taskName: 'db:cleanup'
+    }
+  ])
+
+  await schedulerPlugin(app)
+
+  const jobs = await app.collectSchedulerJobs()
+
+  assert.strictEqual(jobs.length, 2)
+  assert.strictEqual(jobs[0].name, 'cleanup')
+  assert.strictEqual(jobs[0].source, 'config')
+  assert.strictEqual(jobs[1].name, 'frontend:db:cleanup')
+  assert.strictEqual(jobs[1].source, 'nitro')
+  assert.strictEqual(jobs[1].applicationId, 'frontend')
+  assert.strictEqual(jobs[1].taskName, 'db:cleanup')
+})
+
+test('external mode: should switch the application-level schedulers to external', async (t) => {
+  const app = createMockApp(0)
+
+  app.watt.runtime.getScheduler = async () => ([
+    { name: 'cleanup', cron: '0 * * * *', callbackUrl: 'http://x.plt.local/y', source: 'config' },
+    { name: 'frontend:log', cron: '* * * * *', source: 'nitro', applicationId: 'frontend', taskName: 'log' },
+    { name: 'frontend:sync', cron: '* * * * *', source: 'nitro', applicationId: 'frontend', taskName: 'sync' }
+  ])
+
+  const modeChanges = []
+  app.watt.runtime.setApplicationSchedulerMode = async (applicationId, mode) => {
+    modeChanges.push({ applicationId, mode })
+  }
+
+  await schedulerPlugin(app)
+  await app.sendSchedulerInfo()
+
+  // One switch per application, even with multiple tasks
+  assert.deepStrictEqual(modeChanges, [{ applicationId: 'frontend', mode: 'external' }])
+})


### PR DESCRIPTION
## Summary

Adds centralized scheduler coordination between Watt Extra and ICC.

Watt Extra discovers both runtime-configured jobs and application-level scheduled tasks, registers them directly with ICC Cron, suppresses local execution while ICC is configured, and executes application jobs dispatched by ICC over the existing updates WebSocket.

## Changes

### Job Registration

- Uses `runtime.getScheduler()` to collect config and application jobs when supported.
- Registers config jobs with their original callback URL, headers, body, method, and retry settings.
- Registers application jobs without a callback URL, including their `source`, `scheduleId`, and task list.
- Registers config jobs before application jobs.
- Detects an older ICC from a `400` response on the first application job and skips the remaining application registrations.

### Scheduler Ownership

- Pauses runtime-owned scheduler jobs whenever ICC coordination is configured.
- Prevents duplicate local execution across application replicas.
- Leaves scheduler behavior unchanged when Watt Extra runs without ICC.
- Falls back to disabling configured scheduler entries before runtime startup on older Platformatic runtimes.

### Job Execution

- Handles `run-scheduled-job` commands over the updates WebSocket.
- Uses `runtime.runSchedulerJob(name)` for runtime-owned config and application jobs.
- Returns correlated success or failure results to ICC using the command `requestId`.
- Preserves the legacy callback execution path for older runtimes.
- Routes legacy `.plt.local` callbacks through `runtime.inject()` and external callbacks through HTTP.
- Treats non-2xx callback responses as execution failures.

### Compatibility

- New runtimes provide scheduler discovery, pausing, and native execution.
- Older runtimes retain config-based job discovery and callback execution.
- Older ICC versions continue receiving config jobs and safely skip unsupported application jobs.
- Standalone Watt Extra instances continue running jobs locally.

## Review Guide

1. `plugins/scheduler.js`
   - Review scheduler discovery, direct ICC registration, old-ICC detection, and legacy execution fallback.

2. `lib/watt.js`
   - Review local scheduler suppression for both current and older Platformatic runtimes.

3. `plugins/update.js`
   - Review correlated WebSocket command results and failure propagation.

4. `test/scheduler-coordination.test.js`
   - Review coverage for config jobs, application jobs, legacy runtimes, old ICC behavior, and standalone execution.

## Dependencies

- Requires scheduler control APIs from [platformatic/platformatic#4951](https://github.com/platformatic/platformatic/pull/4951).
- Application-job coordination is implemented with [ICC PR #921](https://github.com/platformatic/icc-3/pull/921).

Assisted-By: OpenAI:GPT-5.6-sol <openai/gpt-5.6-sol>
