### PR TITLE
fix: do not clobber env-provided PLT_LOG_LEVEL from cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 import commist from 'commist'
 import minimist from 'minimist'
 import { resolve, join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import helpMeInit from 'help-me'
 import { readFileSync } from 'node:fs'
 import { start, logger } from './index.js'
@@ -27,14 +27,11 @@ function version () {
   }
 }
 
-// Handle start command
-async function startCommand (argv) {
-  if (process.stdout.isTTY) {
-    console.log(getSimpleBanner(pkg.version))
-  } else {
-    logger.info(`WattExtra v${pkg.version}`)
-  }
-
+// Parse start command argv and apply CLI options to env.
+// Precedence for PLT_LOG_LEVEL: --log-level flag > pre-set env > 'info' default.
+// Do NOT add a minimist default for `log-level`: that would make args['log-level']
+// always truthy and unconditionally clobber an env-provided value.
+export function applyStartArgs (argv, env = process.env) {
   const args = minimist(argv, {
     alias: {
       h: 'help',
@@ -46,33 +43,50 @@ async function startCommand (argv) {
     boolean: ['help'],
     string: ['log-level', 'icc-url', 'app-name', 'app-dir'],
     default: {
-      'log-level': 'info',
       'app-dir': process.cwd()
     }
   })
 
-  logger.debug({ args, argv }, 'Start command arguments')
-
   if (args.help) {
-    helpMe.toStdout('start')
-    return true
+    return { args, help: true }
   }
 
-  // Set environment variables based on CLI options
   if (args['log-level']) {
-    process.env.PLT_LOG_LEVEL = args['log-level']
+    env.PLT_LOG_LEVEL = args['log-level']
+  } else if (!env.PLT_LOG_LEVEL) {
+    env.PLT_LOG_LEVEL = 'info'
   }
 
   if (args['icc-url']) {
-    process.env.PLT_ICC_URL = args['icc-url']
+    env.PLT_ICC_URL = args['icc-url']
   }
 
   if (args['app-name']) {
-    process.env.PLT_APP_NAME = args['app-name']
+    env.PLT_APP_NAME = args['app-name']
   }
 
   if (args['app-dir']) {
-    process.env.PLT_APP_DIR = resolve(args['app-dir']) // Ensure the path is absolute
+    env.PLT_APP_DIR = resolve(args['app-dir']) // Ensure the path is absolute
+  }
+
+  return { args, help: false }
+}
+
+// Handle start command
+async function startCommand (argv) {
+  if (process.stdout.isTTY) {
+    console.log(getSimpleBanner(pkg.version))
+  } else {
+    logger.info(`WattExtra v${pkg.version}`)
+  }
+
+  const { args, help } = applyStartArgs(argv)
+
+  logger.debug({ args, argv }, 'Start command arguments')
+
+  if (help) {
+    helpMe.toStdout('start')
+    return true
   }
 
   await start()
@@ -144,4 +158,6 @@ async function run () {
   }
 }
 
-run()
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run()
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/watt-extra",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "The Platformatic runtime manager",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/watt-extra",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "The Platformatic runtime manager",
   "type": "module",
   "scripts": {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,8 +1,9 @@
 import assert from 'node:assert'
 import { test } from 'node:test'
 import { spawn } from 'node:child_process'
-import { join, dirname } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { applyStartArgs } from '../cli.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -89,4 +90,52 @@ test('CLI should output JSON log without banner in non-TTY mode (version command
     stdout.includes('"msg":"WattExtra v'),
     'Non-TTY output should include JSON log with version'
   )
+})
+
+test('applyStartArgs: --log-level flag overrides env-provided PLT_LOG_LEVEL', () => {
+  const env = { PLT_LOG_LEVEL: 'warn' }
+  applyStartArgs(['--log-level', 'debug'], env)
+  assert.strictEqual(env.PLT_LOG_LEVEL, 'debug')
+})
+
+test('applyStartArgs: -l short flag also overrides env', () => {
+  const env = { PLT_LOG_LEVEL: 'warn' }
+  applyStartArgs(['-l', 'trace'], env)
+  assert.strictEqual(env.PLT_LOG_LEVEL, 'trace')
+})
+
+// Regression test: cli.js used to have `default: { 'log-level': 'info' }` in its
+// minimist config, which populated args['log-level'] with 'info' whenever the flag
+// was not passed. The subsequent unconditional write to process.env.PLT_LOG_LEVEL
+// then silently clobbered the value provided by the deployment environment (e.g.
+// PLT_LOG_LEVEL=warn from k8s), forcing the runtime to log at info regardless.
+test('applyStartArgs: preserves env-provided PLT_LOG_LEVEL when --log-level is not passed', () => {
+  const env = { PLT_LOG_LEVEL: 'warn' }
+  applyStartArgs([], env)
+  assert.strictEqual(env.PLT_LOG_LEVEL, 'warn')
+})
+
+test('applyStartArgs: defaults PLT_LOG_LEVEL to "info" when neither env nor flag is set', () => {
+  const env = {}
+  applyStartArgs([], env)
+  assert.strictEqual(env.PLT_LOG_LEVEL, 'info')
+})
+
+test('applyStartArgs: passes through other CLI options to env', () => {
+  const env = {}
+  applyStartArgs([
+    '--icc-url', 'http://icc.example',
+    '--app-name', 'my-app',
+    '--app-dir', 'test/fixtures/runtime-service'
+  ], env)
+  assert.strictEqual(env.PLT_ICC_URL, 'http://icc.example')
+  assert.strictEqual(env.PLT_APP_NAME, 'my-app')
+  assert.strictEqual(env.PLT_APP_DIR, resolve('test/fixtures/runtime-service'))
+})
+
+test('applyStartArgs: --help short-circuits without mutating env', () => {
+  const env = {}
+  const res = applyStartArgs(['--help'], env)
+  assert.strictEqual(res.help, true)
+  assert.strictEqual(env.PLT_LOG_LEVEL, undefined)
 })


### PR DESCRIPTION
Regression bug: `cli.js` had a minimist default of `'log-level': 'info'` combined with an unconditional `process.env.PLT_LOG_LEVEL = args['log-level']`. Because minimist populates defaults into the parsed args object even when the flag is not passed, the start command overwrote every env-provided `PLT_LOG_LEVEL` with `'info'` before spawning the runtime. 
Deployments that set `PLT_LOG_LEVEL=warn` (or anything other than info) in the pod env were silently forced back to info, so the runtime and all Fastify request-lifecycle logs kept firing at info level.

The bug shipped with the initial migration from wattpro (commit 585435c) and has affected every watt-extra release since 1.0.0.