### PR TITLE
fix: restore cli run() so watt-extra works via global bin symlink

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import commist from 'commist'
-import minimist from 'minimist'
-import { resolve, join, dirname } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import helpMeInit from 'help-me'
 import { readFileSync } from 'node:fs'
 import { start, logger } from './index.js'
 import { getSimpleBanner } from './lib/banner.js'
+import { applyStartArgs } from './lib/start-args.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -25,51 +25,6 @@ function version () {
   } else {
     logger.info(`WattExtra v${pkg.version}`)
   }
-}
-
-// Parse start command argv and apply CLI options to env.
-// Precedence for PLT_LOG_LEVEL: --log-level flag > pre-set env > 'info' default.
-// Do NOT add a minimist default for `log-level`: that would make args['log-level']
-// always truthy and unconditionally clobber an env-provided value.
-export function applyStartArgs (argv, env = process.env) {
-  const args = minimist(argv, {
-    alias: {
-      h: 'help',
-      l: 'log-level',
-      i: 'icc-url',
-      a: 'app-name',
-      d: 'app-dir'
-    },
-    boolean: ['help'],
-    string: ['log-level', 'icc-url', 'app-name', 'app-dir'],
-    default: {
-      'app-dir': process.cwd()
-    }
-  })
-
-  if (args.help) {
-    return { args, help: true }
-  }
-
-  if (args['log-level']) {
-    env.PLT_LOG_LEVEL = args['log-level']
-  } else if (!env.PLT_LOG_LEVEL) {
-    env.PLT_LOG_LEVEL = 'info'
-  }
-
-  if (args['icc-url']) {
-    env.PLT_ICC_URL = args['icc-url']
-  }
-
-  if (args['app-name']) {
-    env.PLT_APP_NAME = args['app-name']
-  }
-
-  if (args['app-dir']) {
-    env.PLT_APP_DIR = resolve(args['app-dir']) // Ensure the path is absolute
-  }
-
-  return { args, help: false }
 }
 
 // Handle start command
@@ -158,6 +113,4 @@ async function run () {
   }
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  run()
-}
+run()

--- a/lib/start-args.js
+++ b/lib/start-args.js
@@ -1,0 +1,47 @@
+import minimist from 'minimist'
+import { resolve } from 'node:path'
+
+// Parse start command argv and apply CLI options to env.
+// Precedence for PLT_LOG_LEVEL: --log-level flag > pre-set env > 'info' default.
+// Do NOT add a minimist default for `log-level`: that would make args['log-level']
+// always truthy and unconditionally clobber an env-provided value.
+export function applyStartArgs (argv, env = process.env) {
+  const args = minimist(argv, {
+    alias: {
+      h: 'help',
+      l: 'log-level',
+      i: 'icc-url',
+      a: 'app-name',
+      d: 'app-dir'
+    },
+    boolean: ['help'],
+    string: ['log-level', 'icc-url', 'app-name', 'app-dir'],
+    default: {
+      'app-dir': process.cwd()
+    }
+  })
+
+  if (args.help) {
+    return { args, help: true }
+  }
+
+  if (args['log-level']) {
+    env.PLT_LOG_LEVEL = args['log-level']
+  } else if (!env.PLT_LOG_LEVEL) {
+    env.PLT_LOG_LEVEL = 'info'
+  }
+
+  if (args['icc-url']) {
+    env.PLT_ICC_URL = args['icc-url']
+  }
+
+  if (args['app-name']) {
+    env.PLT_APP_NAME = args['app-name']
+  }
+
+  if (args['app-dir']) {
+    env.PLT_APP_DIR = resolve(args['app-dir']) // Ensure the path is absolute
+  }
+
+  return { args, help: false }
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -3,7 +3,7 @@ import { test } from 'node:test'
 import { spawn } from 'node:child_process'
 import { join, resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { applyStartArgs } from '../cli.js'
+import { applyStartArgs } from '../lib/start-args.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)


### PR DESCRIPTION
Follow-up to #209.

That PR added an `if (import.meta.url === pathToFileURL(process.argv[1]).href) run()` guard on cli.js so tests could `import { applyStartArgs }` without the CLI running as a side effect. The guard was broken for global npm bins: `process.argv[1]` points at the bin symlink (e.g. `/home/node/.npm-global/bin/watt-extra`) while `import.meta.url` resolves to the target (`.../lib/node_modules/@platformatic/watt-extra/cli.js`). The two never match, `run()` never fires, and `watt-extra start` silently exits 0 with no output. In our deployment this broke the pod: containers came up, printed nothing, exited 0, CrashLoopBackOff.

Fix: move `applyStartArgs` into its own module (`lib/start-args.js`) so cli.js can go back to unconditional `run()` at the bottom. Test imports from `../lib/start-args.js` instead of `../cli.js`. No isMain check, no symlink workaround, no future risk of another symlink-shaped regression.

