### PR TITLE
Fix disable watch in production

### DIFF
--- a/lib/watt.js
+++ b/lib/watt.js
@@ -162,8 +162,10 @@ class Watt {
 
     const runtime = await create(this.#appDir, null, {
       isProduction: true,
-      transform: async (config) => {
-        config = await transform(config)
+      transform: async (config, schema, options) => {
+        // Forward schema and options: the runtime's transform reads isProduction
+        // from options, and defaults watch to !isProduction when it is missing.
+        config = await transform(config, schema, options)
 
         this.#config = config
         this.#originalConfig = structuredClone(config)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformatic/watt-extra",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "The Platformatic runtime manager",
   "type": "module",
   "scripts": {

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -1,0 +1,54 @@
+import assert from 'node:assert'
+import { test } from 'node:test'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { randomUUID } from 'node:crypto'
+import { setUpEnvironment, startICC, installDeps } from './helper.js'
+import { start } from '../index.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// watt-extra always starts the runtime with isProduction: true, so the runtime
+// must resolve watch to false. The runtime defaults watch to !isProduction, and
+// reads isProduction from the options passed to its transform, so a transform
+// that does not forward them silently enables file watching in production.
+// This needs a @platformatic/runtime app: a single-application config instead
+// goes through wrapInRuntimeConfig, which never calls the custom transform.
+test('should disable file watching in production', async (t) => {
+  const appName = 'test-app'
+  const applicationId = randomUUID()
+  const applicationPath = join(__dirname, 'fixtures', 'runtime-service')
+
+  await installDeps(t, applicationPath)
+
+  const icc = await startICC(t, {
+    applicationId,
+    port: 3011
+  })
+
+  setUpEnvironment({
+    PLT_APP_NAME: appName,
+    PLT_APP_DIR: applicationPath,
+    PLT_ICC_URL: icc.iccUrl,
+    PLT_CONTROL_PLANE_URL: 'http://127.0.0.1:3012',
+    PLT_APP_PORT: 3053,
+    PLT_METRICS_PORT: 9102
+  })
+
+  const app = await start()
+
+  t.after(async () => {
+    await app.close()
+    await icc.close()
+  })
+
+  const mainConfig = app.watt.runtime.getRuntimeConfig(true)
+
+  assert.strictEqual(mainConfig.watch, false)
+
+  for (const application of mainConfig.applications ?? []) {
+    assert.strictEqual(application.watch, false, `application ${application.id} must not watch files`)
+  }
+})


### PR DESCRIPTION
## What

`Watt#createRuntime` passes a custom `transform` to `@platformatic/runtime`'s `create()`. That
transform accepted only `config` and re-invoked the runtime's own `transform` with a single
argument, dropping `schema` and `options`.

The runtime reads `isProduction` from those options:

```js
export async function transform (config, _, context) {
  const production = context?.isProduction ?? context?.production
  ...
  } else if (watchType === 'undefined') {
    config.watch = !production
```

With the options dropped `production` is `undefined`, and `!undefined === true`, so file watching is
enabled in production even though watt-extra explicitly starts the runtime with `isProduction: true`.


## Solution

Forward `schema` and `options` to the runtime's `transform`, so it sees the `isProduction: true`
that `create()` was already given:

```diff
-      transform: async (config) => {
-        config = await transform(config)
+      transform: async (config, schema, options) => {
+        config = await transform(config, schema, options)
```

`config.watch` now resolves to `false` in production, and no `FileWatcher` is created.

Covered by `test/watch.test.js`, which boots a `@platformatic/runtime` fixture through `start()` and
asserts `watch` is `false` on the resolved runtime config and on every application. The fixture
matters: a `@platformatic/service` fixture passes even without the fix, because it goes through
`wrapInRuntimeConfig` and never reaches the custom transform.
