### PR TITLE
fix: report partial and unresponsive profiling states

### DIFF
--- a/plugins/env.js
+++ b/plugins/env.js
@@ -24,6 +24,7 @@ const schema = {
     PLT_FLAMEGRAPHS_ATTEMPT_TIMEOUT: { type: 'number', default: 10000 },
     PLT_FLAMEGRAPHS_CACHE_CLEANUP_INTERVAL: { type: 'number', default: 120000 },
     PLT_FLAMEGRAPHS_STATE_REPORT_INTERVAL: { type: 'number', default: 30000 },
+    PLT_FLAMEGRAPHS_STATE_QUERY_TIMEOUT: { type: 'number', default: 5000 },
     PLT_JWT_EXPIRATION_OFFSET_SEC: { type: 'number', default: 60 },
     PLT_UPDATES_RECONNECT_INTERVAL_SEC: { type: 'number', default: 1 },
     PLT_ELU_HEALTH_SIGNAL_THRESHOLD: { type: 'number', default: 0.7 },

--- a/plugins/flamegraphs.js
+++ b/plugins/flamegraphs.js
@@ -19,8 +19,19 @@ async function flamegraphs (app, _opts) {
   const maxAttempts = Math.ceil(durationMillis / attemptTimeout) + 1
   const cacheCleanupInterval = parseInt(flamegraphsCacheCleanupInterval)
   const stateReportInterval = parseInt(app.env.PLT_FLAMEGRAPHS_STATE_REPORT_INTERVAL ?? 30000)
+  const stateQueryTimeout = parseInt(app.env.PLT_FLAMEGRAPHS_STATE_QUERY_TIMEOUT ?? 5000)
 
   const PROFILE_TYPES = ['cpu', 'heap']
+  const kStateQueryTimeout = Symbol('kStateQueryTimeout')
+
+  // Workers whose event loop did not answer a state query in time. The
+  // timeout only bounds the report: the underlying ITC request cannot be
+  // cancelled and stays pending in the runtime until the worker answers, so
+  // querying a blocked worker on every interval would leak one pending
+  // request per query. Further queries are suppressed with a bounded
+  // backoff; the suppression is cleared when the worker restarts or answers.
+  const STATE_QUERY_BACKOFF_MAX = 5 * 60 * 1000
+  const unresponsiveWorkers = new Map()
 
   // Desired profiling state for this pod. It can be changed at runtime by the
   // start-profiling/stop-profiling ICC commands and it gates the
@@ -119,11 +130,14 @@ async function flamegraphs (app, _opts) {
 
     // Listen for new workers starting and start profiling on them
     workerStartedListener = ({ application, worker }) => {
+      const workerFullId = [application, worker].join(':')
+
+      // A restarted worker has a fresh event loop: query its state again
+      unresponsiveWorkers.delete(workerFullId)
+
       if (enabledTypes.size === 0) {
         return
       }
-
-      const workerFullId = [application, worker].join(':')
       app.log.info({ application, worker }, 'Starting profiling on new worker')
 
       startProfilingOnWorker(runtime, workerFullId, [...enabledTypes], { application, worker }).catch(() => {
@@ -221,20 +235,25 @@ async function flamegraphs (app, _opts) {
     }
 
     const results = await Promise.allSettled(promises)
+    let failures = 0
     for (const result of results) {
       if (result.status === 'rejected') {
+        failures++
         app.log.error({ result, enabled }, 'Failed to toggle profiling on a worker')
       }
     }
 
-    app.log.info({ enabled, types: validTypes }, 'Profiling toggled')
+    app.log.info({ enabled, types: validTypes, failures }, 'Profiling toggled')
 
-    // Report the new state right away so the UI converges quickly
+    // Report the new state right away so the UI converges quickly. The
+    // report carries the real per-worker profiler state (isCapturing), so a
+    // worker which failed to toggle is reconciled by ICC from that, not from
+    // the enabledTypes intent.
     reportProfilingStates().catch((err) => {
       app.log.error({ err }, 'Failed to report profiling states')
     })
 
-    return { success: true, enabled, types: [...enabledTypes] }
+    return { success: failures === 0, enabled, types: [...enabledTypes], failures }
   }
 
   const profilesByWorkerId = {}
@@ -497,8 +516,33 @@ async function flamegraphs (app, _opts) {
   // Collects the real profiling state of every worker and reports it to the
   // scaler together with the pod's desired state. The report expires in
   // Valkey, so a pod which stops reporting naturally disappears from the UI.
+  //
+  // Concurrent invocations are coalesced: while a report is running, a new
+  // request queues at most one re-run after it, so a slow scaler or a
+  // blocked worker cannot pile up overlapping reports.
+  let reportInFlight = null
+  let reportQueued = false
+
   app.reportProfilingStates = reportProfilingStates
-  async function reportProfilingStates () {
+  function reportProfilingStates () {
+    if (reportInFlight) {
+      reportQueued = true
+      return reportInFlight
+    }
+
+    reportInFlight = collectAndSendProfilingStates().finally(() => {
+      reportInFlight = null
+      if (reportQueued) {
+        reportQueued = false
+        reportProfilingStates().catch((err) => {
+          app.log.error({ err }, 'Failed to report profiling states')
+        })
+      }
+    })
+    return reportInFlight
+  }
+
+  async function collectAndSendProfilingStates () {
     if (!stateReportingSupported) {
       return
     }
@@ -515,50 +559,116 @@ async function flamegraphs (app, _opts) {
     }
 
     const workers = await runtime.getWorkers()
-    const states = []
+
+    // One blocked worker must not prevent the others from being reported:
+    // the queries run in parallel and each is bounded by a timeout
+    const queries = []
     for (const [workerFullId, workerInfo] of Object.entries(workers)) {
       if (workerInfo.status !== 'started') {
         continue
       }
+
       const serviceId = workerFullId.split(':')[0]
 
+      // A suppressed worker is still part of the report: an explicit
+      // unresponsive entry keeps ICC from treating the remaining healthy
+      // workers as the whole pod
+      const suppression = unresponsiveWorkers.get(workerFullId)
+      if (suppression && Date.now() < suppression.skipUntil) {
+        app.log.debug({ workerFullId }, 'Skipping the state query of an unresponsive worker')
+        for (const type of PROFILE_TYPES) {
+          queries.push(Promise.resolve(unresponsiveState(workerFullId, serviceId, type)))
+        }
+        continue
+      }
+
       for (const type of PROFILE_TYPES) {
-        let state = null
-        try {
-          state = await runtime.sendCommandToApplication(
-            workerFullId,
-            'getProfilingState',
-            { type }
-          )
-        } catch (err) {
-          app.log.warn({ err, workerFullId, type }, 'Failed to get profiling state from worker')
-          continue
-        }
-
-        // A runtime without the pprof capture command answers with an
-        // empty object
-        if (!state || state.isCapturing === undefined) {
-          states.push({
-            serviceId,
-            workerId: workerFullId,
-            type,
-            enabled: enabledTypes.has(type),
-            unsupported: true
-          })
-          continue
-        }
-
-        states.push({
-          serviceId,
-          workerId: workerFullId,
-          type,
-          enabled: enabledTypes.has(type),
-          ...state
-        })
+        queries.push(getWorkerProfilingState(runtime, workerFullId, serviceId, type))
       }
     }
 
+    const states = await Promise.all(queries)
+
     await sendProfilingStates(scalerUrl, applicationId, states)
+  }
+
+  // A worker whose profiling state cannot be read still appears in the
+  // report: ICC must know the state is unknown rather than assume the
+  // reported workers are the whole pod
+  function unresponsiveState (workerFullId, serviceId, type) {
+    return {
+      serviceId,
+      workerId: workerFullId,
+      type,
+      enabled: enabledTypes.has(type),
+      unresponsive: true
+    }
+  }
+
+  // Queries one worker for its profiling state of one type. Reports the
+  // worker as unresponsive when it cannot answer: the query has no timeout
+  // of its own and hangs if the worker event loop is blocked, which is
+  // likely exactly when profiling is in use, so it is bounded here.
+  async function getWorkerProfilingState (runtime, workerFullId, serviceId, type) {
+    let state = null
+    try {
+      const query = runtime.sendCommandToApplication(
+        workerFullId,
+        'getProfilingState',
+        { type }
+      )
+      // A settlement after the timeout must not surface as an unhandled
+      // rejection
+      query.catch(() => {})
+
+      state = await Promise.race([
+        query,
+        sleep(stateQueryTimeout, kStateQueryTimeout, { ref: false })
+      ])
+
+      if (state === kStateQueryTimeout) {
+        // Both types of the same worker time out together: escalate the
+        // backoff only once per cycle
+        const existing = unresponsiveWorkers.get(workerFullId)
+        if (!existing || Date.now() >= existing.skipUntil) {
+          const backoff = Math.min(
+            existing ? existing.backoff * 2 : stateReportInterval,
+            STATE_QUERY_BACKOFF_MAX
+          )
+          unresponsiveWorkers.set(workerFullId, { skipUntil: Date.now() + backoff, backoff })
+        }
+        app.log.warn(
+          { workerFullId, type, stateQueryTimeout },
+          'Timed out getting the profiling state from a worker, suppressing its state queries'
+        )
+        return unresponsiveState(workerFullId, serviceId, type)
+      }
+
+      unresponsiveWorkers.delete(workerFullId)
+    } catch (err) {
+      app.log.warn({ err, workerFullId, type }, 'Failed to get profiling state from worker')
+      return unresponsiveState(workerFullId, serviceId, type)
+    }
+
+    // A runtime without the pprof capture command answers with an
+    // empty object
+    if (!state || state.isCapturing === undefined) {
+      return {
+        serviceId,
+        workerId: workerFullId,
+        type,
+        enabled: enabledTypes.has(type),
+        unsupported: true
+      }
+    }
+
+    return {
+      serviceId,
+      workerId: workerFullId,
+      type,
+      enabled: enabledTypes.has(type),
+      ...state
+    }
   }
 
   async function sendProfilingStates (scalerUrl, applicationId, states) {

--- a/test/profiling-toggle.test.js
+++ b/test/profiling-toggle.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import { equal, ok, deepEqual } from 'node:assert'
 import { once } from 'node:events'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { WebSocketServer } from 'ws'
 import fastify from 'fastify'
 import { setUpEnvironment } from './helper.js'
@@ -147,8 +148,17 @@ async function startScalerMock (t, opts = {}) {
     }
   }
 
+  let activeStatesRequests = 0
+  let maxConcurrentStatesRequests = 0
+
   if (!opts.withoutStatesRoute) {
     scaler.post('/scaler/flamegraphs/states', async (req) => {
+      activeStatesRequests++
+      maxConcurrentStatesRequests = Math.max(maxConcurrentStatesRequests, activeStatesRequests)
+      if (opts.statesDelay) {
+        await sleep(opts.statesDelay)
+      }
+      activeStatesRequests--
       statesReports.push(req.body)
       notifyReportWaiters()
       return {}
@@ -169,7 +179,13 @@ async function startScalerMock (t, opts = {}) {
   }
 
   const url = `http://127.0.0.1:${scaler.server.address().port}/scaler`
-  return { scaler, statesReports, url, waitForReports }
+  return {
+    scaler,
+    statesReports,
+    url,
+    waitForReports,
+    getMaxConcurrentStatesRequests: () => maxConcurrentStatesRequests
+  }
 }
 
 // The worker-started listener logs this message synchronously before arming a
@@ -561,4 +577,170 @@ test('handles start-profiling and stop-profiling commands from ICC', async (t) =
   const cpuStopCalls = app.commandCalls.filter((c) => c.command === 'stopProfiling')
   equal(cpuStopCalls.length, 2)
   ok(cpuStopCalls.every((c) => c.options.type === 'cpu'))
+})
+
+test('a partial worker failure is not reported as success and the report carries the real state', async (t) => {
+  setUpEnvironment()
+
+  const { statesReports, url, waitForReports } = await startScalerMock(t)
+  const failingWorker = 'service-2:0'
+  const capturing = { 'service-1:0': false, 'service-2:0': false }
+  const app = createMockApp({
+    scalerUrl: url,
+    sendCommandToApplication: async (workerId, command, options) => {
+      if (command === 'startProfiling') {
+        if (workerId === failingWorker) {
+          throw new Error('boom')
+        }
+        capturing[workerId] = true
+        return {}
+      }
+      if (command === 'stopProfiling') {
+        capturing[workerId] = false
+        return {}
+      }
+      if (command === 'getProfilingState') {
+        return {
+          isCapturing: capturing[workerId],
+          isProfilerRunning: capturing[workerId],
+          isPaused: false
+        }
+      }
+      return {}
+    }
+  })
+
+  await flamegraphsPlugin(app)
+
+  await app.setProfilingEnabled(false)
+  const result = await app.setProfilingEnabled(true)
+
+  // The toggle is not a success and the intent is still recorded
+  equal(result.success, false)
+  equal(result.failures, 1)
+  deepEqual(result.types.sort(), ['cpu', 'heap'])
+
+  // The report distinguishes intent (enabled) from reality (isCapturing)
+  await waitForReports(2)
+  const report = statesReports[statesReports.length - 1]
+  const failedState = report.states.find((s) => s.workerId === failingWorker && s.type === 'cpu')
+  equal(failedState.enabled, true)
+  equal(failedState.isCapturing, false)
+  const okState = report.states.find((s) => s.workerId === 'service-1:0' && s.type === 'cpu')
+  equal(okState.enabled, true)
+  equal(okState.isCapturing, true)
+})
+
+test('a blocked worker does not stall the state report', async (t) => {
+  setUpEnvironment()
+
+  const { statesReports, url, waitForReports } = await startScalerMock(t)
+  const app = createMockApp({
+    scalerUrl: url,
+    env: { PLT_FLAMEGRAPHS_STATE_QUERY_TIMEOUT: 100 },
+    sendCommandToApplication: async (workerId, command) => {
+      if (command === 'getProfilingState' && workerId === 'service-1:0') {
+        // A blocked worker event loop: the query never settles
+        return new Promise(() => {})
+      }
+      if (command === 'getProfilingState') {
+        return {
+          isCapturing: true,
+          isProfilerRunning: true,
+          isPaused: false
+        }
+      }
+      return {}
+    }
+  })
+
+  await flamegraphsPlugin(app)
+  await app.reportProfilingStates()
+  await waitForReports(1)
+
+  // The blocked worker is reported as unresponsive, the healthy one normally
+  const report = statesReports[0]
+  equal(report.states.length, 4)
+  const blockedStates = report.states.filter((s) => s.workerId === 'service-1:0')
+  equal(blockedStates.length, 2)
+  ok(blockedStates.every((s) => s.unresponsive === true))
+  const healthyStates = report.states.filter((s) => s.workerId === 'service-2:0')
+  equal(healthyStates.length, 2)
+  ok(healthyStates.every((s) => s.isCapturing === true && s.unresponsive === undefined))
+})
+
+test('overlapping state reports are coalesced', async (t) => {
+  setUpEnvironment()
+
+  const mock = await startScalerMock(t, { statesDelay: 100 })
+  const app = createMockApp({ scalerUrl: mock.url })
+
+  await flamegraphsPlugin(app)
+
+  // The second call while the first is in flight queues a single re-run
+  const first = app.reportProfilingStates()
+  const second = app.reportProfilingStates()
+  equal(first, second)
+
+  await first
+  await mock.waitForReports(2)
+
+  equal(mock.statesReports.length, 2)
+  equal(mock.getMaxConcurrentStatesRequests(), 1)
+})
+
+test('a timed-out worker is not queried again until it restarts', async (t) => {
+  setUpEnvironment()
+
+  const { statesReports, url, waitForReports } = await startScalerMock(t)
+  const app = createMockApp({
+    scalerUrl: url,
+    env: { PLT_FLAMEGRAPHS_STATE_QUERY_TIMEOUT: 100 },
+    sendCommandToApplication: async (workerId, command) => {
+      if (command === 'getProfilingState' && workerId === 'service-1:0') {
+        // A blocked worker event loop: the query never settles
+        return new Promise(() => {})
+      }
+      if (command === 'getProfilingState') {
+        return {
+          isCapturing: true,
+          isProfilerRunning: true,
+          isPaused: false
+        }
+      }
+      return {}
+    }
+  })
+
+  const queriesToBlockedWorker = () => app.commandCalls.filter(
+    (c) => c.command === 'getProfilingState' && c.workerId === 'service-1:0'
+  ).length
+
+  await flamegraphsPlugin(app)
+  await app.setupFlamegraphs()
+  t.after(() => app.cleanupFlamegraphs())
+
+  // The first report queries the blocked worker, times out, and suppresses it
+  await waitForReports(1)
+  equal(queriesToBlockedWorker(), 2)
+
+  // The next report does not query the suppressed worker but still reports
+  // it as unresponsive
+  await app.reportProfilingStates()
+  await waitForReports(2)
+  equal(queriesToBlockedWorker(), 2)
+  const suppressedReport = statesReports[statesReports.length - 1]
+  equal(suppressedReport.states.length, 4)
+  ok(suppressedReport.states
+    .filter((s) => s.workerId === 'service-1:0')
+    .every((s) => s.unresponsive === true))
+
+  // A worker restart clears the suppression and it is queried again
+  app.watt.runtime.emit('application:worker:started', {
+    application: 'service-1',
+    worker: 0
+  })
+  await app.reportProfilingStates()
+  await waitForReports(3)
+  equal(queriesToBlockedWorker(), 4)
 })


### PR DESCRIPTION
## Summary

Profiling state reporting previously treated pod-side intent as actual state and could stall indefinitely when a worker event loop was blocked. This could make partial activation appear successful or cause the pod state to expire from ICC.

This change:

- reports the real `isCapturing` state for every worker and profile type
- returns a failed toggle result when one or more workers fail to start or stop profiling
- queries worker states in parallel with a configurable timeout
- coalesces concurrent reports so slow workers or scaler requests do not create overlapping runs
- applies bounded backoff to workers whose state queries time out
- keeps timed-out workers in reports as `unresponsive`, allowing ICC to show `Pending`, `Partial`, or `Unknown` instead of treating the healthy subset as the whole pod
- clears worker suppression when the worker restarts

## Configuration

Adds `PLT_FLAMEGRAPHS_STATE_QUERY_TIMEOUT`, in milliseconds, with a default of `5000`.
