### PR TITLE
feat: disable flamegraphs by default

### DIFF
--- a/plugins/env.js
+++ b/plugins/env.js
@@ -17,7 +17,7 @@ const schema = {
     PLT_APP_INTERNAL_SUB_DOMAIN: { type: 'string', default: 'plt.local' },
     PLT_DEFAULT_CACHE_TAGS_HEADER: { type: 'string', default: 'x-plt-cache-tags' },
     PLT_CACHE_CONFIG: { type: 'string' },
-    PLT_DISABLE_FLAMEGRAPHS: { type: 'boolean', default: false },
+    PLT_DISABLE_FLAMEGRAPHS: { type: 'boolean', default: true },
     PLT_FLAMEGRAPHS_INTERVAL_SEC: { type: 'number', default: 60 },
     PLT_FLAMEGRAPHS_ELU_THRESHOLD: { type: 'number', default: 0.4 },
     PLT_FLAMEGRAPHS_GRACE_PERIOD: { type: 'number', default: 3000 },


### PR DESCRIPTION
Flips the default of `PLT_DISABLE_FLAMEGRAPHS` from `false` to `true`: pods now boot with continuous profiling **off** unless a deployment explicitly opts in.

## Why this makes sense now

Until #229, this default was the only control profiling had: it was set at boot, for the whole pod, forever. Disabling by default would have meant nobody gets flamegraphs at all, so profiling-on was the only usable default.

That constraint is gone. Since #229 (and the ICC per-pod toggle UI):

- **Profiling is activatable at runtime, per pod.** An operator investigating one misbehaving pod activates exactly that pod from the ICC Flamegraphs page, collects the profile, and deactivates it (or lets the pod's restart revert it). The pprof capture preload is always loaded and stays passive, so activation needs no restart and no env change.
- **The UI tells the truth about the disabled state.** A disabled pod reports its state and shows as **Off** with a working *Activate profiling* button — not as a mysteriously missing feature.
- **Opt-in is the right posture for production profiling.** The profilers are ELU-gated, but once load crosses the threshold they run precisely on the busiest workers at the busiest times. That cost should be a choice, not a side effect of installing watt-extra.

In short: profiling-by-default existed because there was no other way to get a profile. Now that there is, the default can follow the principle of least surprise: do nothing until asked.

## Behavior changes to be aware of

- **Alert-attached flamegraphs are off by default.** Scaling alerts still fire and scale correctly, but they carry no flamegraph evidence unless the pod was activated beforehand (or the deployment opts in). Deployments that rely on alert-attached profiles should set `PLT_DISABLE_FLAMEGRAPHS=false`.

